### PR TITLE
Update bevy_rapier3d to version 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
  "derive_more",
  "downcast-rs 2.0.1",
  "either",
- "petgraph",
+ "petgraph 0.7.1",
  "ron",
  "serde",
  "smallvec",
@@ -1344,9 +1344,9 @@ checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
 
 [[package]]
 name = "bevy_rapier3d"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf74109573c2c82b05b217cb6101f7e71e6c53ad622aed6c370cc5783c59eb8"
+checksum = "3ed7b07ace7682f96ca3860022a0dbd8080d0abd295121e8ce4a3e04dc11e32b"
 dependencies = [
  "bevy",
  "bitflags 2.9.1",
@@ -1372,7 +1372,7 @@ dependencies = [
  "erased-serde",
  "foldhash",
  "glam",
- "petgraph",
+ "petgraph 0.7.1",
  "serde",
  "smallvec",
  "smol_str",
@@ -2299,19 +2299,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -4675,9 +4662,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.20.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec55ce6f725367f8149f750575e79a8879d71b7257c02273259f9375822821f"
+checksum = "5e0877164c86c741f30fcb13e551a37f5805ffc053710644af3ef8080e526f68"
 dependencies = [
  "approx",
  "arrayvec",
@@ -4694,7 +4681,9 @@ dependencies = [
  "rstar",
  "simba",
  "slab",
+ "smallvec",
  "spade",
+ "static_assertions",
  "thiserror 2.0.12",
 ]
 
@@ -4720,6 +4709,18 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+dependencies = [
+ "fixedbitset",
+ "hashbrown",
+ "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -5031,15 +5032,14 @@ checksum = "f93e7e49bb0bf967717f7bd674458b3d6b0c5f48ec7e3038166026a69fc22223"
 
 [[package]]
 name = "rapier3d"
-version = "0.25.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35ec3d01c4f918675411442024a1fbfb7eafdd878a6e82479ff6e461a9092fc"
+checksum = "b274764d058e242961750c11aff7433255321f621bb98220bb0a82beff1f9897"
 dependencies = [
  "approx",
  "arrayvec",
  "bit-vec 0.8.0",
  "bitflags 2.9.1",
- "crossbeam",
  "downcast-rs 2.0.1",
  "log",
  "nalgebra",
@@ -5047,10 +5047,14 @@ dependencies = [
  "num-traits",
  "ordered-float 5.0.0",
  "parry3d",
+ "petgraph 0.8.2",
  "profiling",
  "rustc-hash 2.1.1",
  "simba",
+ "smallvec",
  "thiserror 2.0.12",
+ "vec_map",
+ "wide",
 ]
 
 [[package]]

--- a/sbepis/Cargo.toml
+++ b/sbepis/Cargo.toml
@@ -22,7 +22,7 @@ movement_indicators = []
 bevy = { version = "0.16.0", features = ["wav", "mp3", "wayland"] }
 bevy-inspector-egui = { version = "0.32.0", optional = true }
 bevy_panorbit_camera = { version = "0.27.0", optional = true }
-bevy_rapier3d = "0.30.0"
+bevy_rapier3d = "0.31.0"
 image = "0.25.2"
 itertools = "0.14.0"
 leafwing-input-manager = "0.17.0"

--- a/sbepis/src/player_controller/camera_controls.rs
+++ b/sbepis/src/player_controller/camera_controls.rs
@@ -80,7 +80,7 @@ pub fn interact_with<T: Component>(
 
     let player_camera = player_camera.single()?;
     let mut hit_entity: Option<(Option<Entity>, f32)> = None;
-    rapier_context.single()?.intersections_with_ray(
+    rapier_context.single()?.intersect_ray(
         player_camera.translation(),
         player_camera.forward().into(),
         3.0,

--- a/sbepis/src/player_controller/movement/grounded.rs
+++ b/sbepis/src/player_controller/movement/grounded.rs
@@ -31,7 +31,7 @@ fn update_is_grounded(
     for (player, transform, body) in bodies.iter_mut() {
         let collider_entity = body.collider;
         let mut contact = None;
-        rapier_context.intersections_with_ray(
+        rapier_context.intersect_ray(
             transform.translation() + transform.up() * 0.05,
             transform.down().into(),
             0.25,

--- a/sbepis/src/player_controller/weapons/mod.rs
+++ b/sbepis/src/player_controller/weapons/mod.rs
@@ -166,7 +166,7 @@ fn sweep_dealers(
         let up = (end_tip - pivot_position).cross(start_tip - pivot_position);
         let rotation = Quat::from_look_to(delta, up);
 
-        let collider = shape::Cuboid::new(Vector3::new(
+        let sweep_shape = shape::Cuboid::new(Vector3::new(
             pivot.sweep_depth * 0.5,
             pivot.sweep_height * 0.5,
             delta.length() * 0.5,
@@ -175,7 +175,7 @@ fn sweep_dealers(
         rapier_context.intersect_shape(
             position,
             rotation,
-            &collider,
+            &sweep_shape,
             QueryFilter::new(),
             |hit_entity| {
                 dealer.hit_entities.insert(hit_entity);
@@ -184,7 +184,7 @@ fn sweep_dealers(
         );
         commands
             .entity(debug_collider_visualizer)
-            .insert(Collider::from(SharedShape::new(collider)))
+            .insert(Collider::from(SharedShape::new(sweep_shape)))
             .insert(Transform::from_translation(position).with_rotation(rotation));
 
         dealer.last_transform = *transform;

--- a/sbepis/src/player_controller/weapons/mod.rs
+++ b/sbepis/src/player_controller/weapons/mod.rs
@@ -2,6 +2,8 @@ use bevy::color::palettes::css;
 use bevy::ecs::entity::EntityHashSet;
 use bevy::prelude::*;
 use bevy_butler::*;
+use bevy_rapier3d::na::Vector3;
+use bevy_rapier3d::parry::shape::{self, SharedShape};
 use bevy_rapier3d::prelude::*;
 
 use crate::entity::{EntityKilled, EntityKilledSet, GelViscosity};
@@ -164,12 +166,13 @@ fn sweep_dealers(
         let up = (end_tip - pivot_position).cross(start_tip - pivot_position);
         let rotation = Quat::from_look_to(delta, up);
 
-        let collider = Collider::cuboid(
+        let collider = shape::Cuboid::new(Vector3::new(
             pivot.sweep_depth * 0.5,
             pivot.sweep_height * 0.5,
             delta.length() * 0.5,
-        );
-        rapier_context.intersections_with_shape(
+        ));
+
+        rapier_context.intersect_shape(
             position,
             rotation,
             &collider,
@@ -181,7 +184,7 @@ fn sweep_dealers(
         );
         commands
             .entity(debug_collider_visualizer)
-            .insert(collider)
+            .insert(Collider::from(SharedShape::new(collider)))
             .insert(Transform::from_translation(position).with_rotation(rotation));
 
         dealer.last_transform = *transform;


### PR DESCRIPTION
Update to bevy_rapier3d version 0.31.0. Changes don't seem to effect us that much-see [the changelog](https://github.com/dimforge/bevy_rapier/blob/master/CHANGELOG.md).

Changes
- intersections_with_ray is now intersect_ray
- intersections_with_shape is now intersect_shape
- intersect_shape takes a Parry3d shape as apposed to a Collider (meaning in the sweep system for weapons we must create a Parry3d shape for the shapecast, and then use `Collider::from(SharedShape::new(collider))` to create the collider for debug.